### PR TITLE
[PR] 🐛 Fix: 지원서 관련 API 수정 및 쿼리 최적화

### DIFF
--- a/src/main/java/com/example/starhub/controller/ApplicationController.java
+++ b/src/main/java/com/example/starhub/controller/ApplicationController.java
@@ -70,14 +70,13 @@ public class ApplicationController implements ApplicationControllerDocs {
     /**
      * 지원서 수정하기
      */
-    @PatchMapping("/applications/{applicationId}")
+    @PatchMapping("/applications/me")
     public ResponseEntity<ResponseDto<ApplicationResponseDto>> updateApplication(
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @PathVariable Long meetingId,
-            @PathVariable Long applicationId,
             @Valid @RequestBody ApplicationRequestDto applicationRequestDto) {
 
-        ApplicationResponseDto res = applicationService.updateApplication(customUserDetails.getUsername(), meetingId, applicationId, applicationRequestDto);
+        ApplicationResponseDto res = applicationService.updateApplication(customUserDetails.getUsername(), meetingId, applicationRequestDto);
         return ResponseEntity
                 .status(ResponseCode.SUCCESS_UPDATE_APPLICANT.getStatus().value())
                 .body(new ResponseDto<>(ResponseCode.SUCCESS_UPDATE_APPLICANT, res));

--- a/src/main/java/com/example/starhub/controller/ApplicationController.java
+++ b/src/main/java/com/example/starhub/controller/ApplicationController.java
@@ -56,13 +56,12 @@ public class ApplicationController implements ApplicationControllerDocs {
     /**
      * 지원서 상세 불러오기
      */
-    @GetMapping("/applications/{applicationId}")
+    @GetMapping("/applications/me")
     public ResponseEntity<ResponseDto<ApplicationResponseDto>> getApplicationDetail(
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails customUserDetails,
-            @PathVariable Long meetingId,
-            @PathVariable Long applicationId) {
+            @PathVariable Long meetingId) {
 
-        ApplicationResponseDto res = applicationService.getApplicationDetail(customUserDetails.getUsername(), meetingId, applicationId);
+        ApplicationResponseDto res = applicationService.getApplicationDetail(customUserDetails.getUsername(), meetingId);
         return ResponseEntity
                 .status(ResponseCode.SUCCESS_GET_APPLICANT_DETAIL.getStatus().value())
                 .body(new ResponseDto<>(ResponseCode.SUCCESS_GET_APPLICANT_DETAIL, res));

--- a/src/main/java/com/example/starhub/controller/ApplicationController.java
+++ b/src/main/java/com/example/starhub/controller/ApplicationController.java
@@ -88,10 +88,9 @@ public class ApplicationController implements ApplicationControllerDocs {
     @DeleteMapping("/applications/{applicationId}")
     public ResponseEntity<ResponseDto> deleteApplication(
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails customUserDetails,
-            @PathVariable Long meetingId,
-            @PathVariable Long applicationId) {
+            @PathVariable Long meetingId) {
 
-        applicationService.deleteApplication(customUserDetails.getUsername(), meetingId, applicationId);
+        applicationService.deleteApplication(customUserDetails.getUsername(), meetingId);
         return ResponseEntity
                 .status(ResponseCode.SUCCESS_DELETE_APPLICANT.getStatus().value())
                 .body(new ResponseDto<>(ResponseCode.SUCCESS_DELETE_APPLICANT, null));

--- a/src/main/java/com/example/starhub/controller/ApplicationController.java
+++ b/src/main/java/com/example/starhub/controller/ApplicationController.java
@@ -85,7 +85,7 @@ public class ApplicationController implements ApplicationControllerDocs {
     /**
      * 지원서 삭제하기
      */
-    @DeleteMapping("/applications/{applicationId}")
+    @DeleteMapping("/applications/me")
     public ResponseEntity<ResponseDto> deleteApplication(
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @PathVariable Long meetingId) {

--- a/src/main/java/com/example/starhub/controller/docs/ApplicationControllerDocs.java
+++ b/src/main/java/com/example/starhub/controller/docs/ApplicationControllerDocs.java
@@ -50,8 +50,7 @@ public interface ApplicationControllerDocs {
     )
     ResponseEntity<ResponseDto<ApplicationResponseDto>> getApplicationDetail(
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails customUserDetails,
-            @PathVariable Long meetingId,
-            @PathVariable Long applicationId);
+            @PathVariable Long meetingId);
 
     /**
      * 지원서 수정하기

--- a/src/main/java/com/example/starhub/controller/docs/ApplicationControllerDocs.java
+++ b/src/main/java/com/example/starhub/controller/docs/ApplicationControllerDocs.java
@@ -73,7 +73,6 @@ public interface ApplicationControllerDocs {
     )
     ResponseEntity<ResponseDto> deleteApplication(
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails customUserDetails,
-            @PathVariable Long meetingId,
-            @PathVariable Long applicationId);
+            @PathVariable Long meetingId);
 
 }

--- a/src/main/java/com/example/starhub/controller/docs/ApplicationControllerDocs.java
+++ b/src/main/java/com/example/starhub/controller/docs/ApplicationControllerDocs.java
@@ -62,7 +62,6 @@ public interface ApplicationControllerDocs {
     ResponseEntity<ResponseDto<ApplicationResponseDto>> updateApplication(
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @PathVariable Long meetingId,
-            @PathVariable Long applicationId,
             @Valid @RequestBody ApplicationRequestDto applicationRequestDto);
 
     /**

--- a/src/main/java/com/example/starhub/dto/response/ApplicationResponseDto.java
+++ b/src/main/java/com/example/starhub/dto/response/ApplicationResponseDto.java
@@ -14,7 +14,7 @@ public class ApplicationResponseDto {
     private Long id;
     private String content;
     private LocalDateTime updatedAt;
-    private ApplicantDto applicant;
+    private ApplicantDto applicant; // 지원자 정보
 
     /**
      * 지원서 관련 정보

--- a/src/main/java/com/example/starhub/entity/ApplicationEntity.java
+++ b/src/main/java/com/example/starhub/entity/ApplicationEntity.java
@@ -13,9 +13,9 @@ import java.time.LocalDateTime;
 
 @Entity
 @Getter
-@Builder
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 @EntityListeners(AuditingEntityListener.class)
 public class ApplicationEntity {
 

--- a/src/main/java/com/example/starhub/repository/ApplicationRepository.java
+++ b/src/main/java/com/example/starhub/repository/ApplicationRepository.java
@@ -5,13 +5,18 @@ import com.example.starhub.entity.MeetingEntity;
 import com.example.starhub.entity.UserEntity;
 import com.example.starhub.entity.enums.ApplicationStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface ApplicationRepository extends JpaRepository<ApplicationEntity, Long> {
     boolean existsByMeetingAndApplicant(MeetingEntity meetingEntity, UserEntity userEntity);
+
+    @Query("SELECT a FROM ApplicationEntity a JOIN FETCH a.applicant WHERE a.meeting = :meetingEntity")
     List<ApplicationEntity> findByMeeting(MeetingEntity meetingEntity);
+
     Optional<ApplicationEntity> findByApplicantAndMeeting(UserEntity userEntity, MeetingEntity meetingEntity);
+
     List<ApplicationEntity> findByMeetingAndStatus(MeetingEntity meetingEntity, ApplicationStatus status);
 }

--- a/src/main/java/com/example/starhub/repository/MeetingRepository.java
+++ b/src/main/java/com/example/starhub/repository/MeetingRepository.java
@@ -2,6 +2,13 @@ package com.example.starhub.repository;
 
 import com.example.starhub.entity.MeetingEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface MeetingRepository extends JpaRepository<MeetingEntity, Long> {
+
+    @Query("SELECT m FROM MeetingEntity m JOIN FETCH m.creator WHERE m.id = :meetingId")
+    Optional<MeetingEntity> findWithCreatorById(@Param("meetingId") Long meetingId);
 }

--- a/src/main/java/com/example/starhub/service/ApplicationService.java
+++ b/src/main/java/com/example/starhub/service/ApplicationService.java
@@ -51,6 +51,15 @@ public class ApplicationService {
     }
 
     /**
+     * 공통 검증 로직: 사용자가 게시글의 개설자가 아님을 확인
+     */
+    private void validateMeetingApplicant(MeetingEntity meetingEntity, String username) {
+        if (meetingEntity.getCreator().getUsername().equals(username)) {
+            throw new ApplicantAuthorizationException(ErrorCode.APPLICATION_FORBIDDEN);
+        }
+    }
+
+    /**
      * 공통 검증 로직: 사용자가 지원자인지 확인
      */
     private void validateApplicant(ApplicationEntity applicationEntity, String username) {
@@ -126,24 +135,19 @@ public class ApplicationService {
      *
      * @param username JWT를 통해 인증된 사용자명
      * @param meetingId 모임 아이디
-     * @param applicationId 지원서 아이디
      * @return 지원서 상세 정보 DTO
      */
     @Transactional(readOnly = true)
-    public ApplicationResponseDto getApplicationDetail(String username, Long meetingId, Long applicationId) {
+    public ApplicationResponseDto getApplicationDetail(String username, Long meetingId) {
 
-        validateAndGetMeeting(meetingId);
+        UserEntity userEntity = validateAndGetUser(username);
+        MeetingEntity meetingEntity = validateAndGetMeeting(meetingId);
 
-        ApplicationEntity applicationEntity = applicationRepository.findById(applicationId)
+        // 개설자가 아님을 확인해야 함
+        validateMeetingApplicant(meetingEntity, username);
+
+        ApplicationEntity applicationEntity = applicationRepository.findByApplicantAndMeeting(userEntity, meetingEntity)
                 .orElseThrow(() -> new ApplicationNotFoundException(ErrorCode.APPLICATION_NOT_FOUND));
-
-        // 해당 지원서가 모임에 포함되는지 확인
-        if (!applicationEntity.getMeeting().getId().equals(meetingId)) {
-            throw new MeetingNotFoundException(ErrorCode.MEETING_NOT_FOUND);
-        }
-
-        // 지원자인지 확인
-        validateApplicant(applicationEntity, username);
 
         // 지원서 상세 정보 반환
         return ApplicationResponseDto.fromEntity(applicationEntity);

--- a/src/main/java/com/example/starhub/service/ApplicationService.java
+++ b/src/main/java/com/example/starhub/service/ApplicationService.java
@@ -29,9 +29,10 @@ public class ApplicationService {
     /**
      * 공통 검증 로직: 모임 가져오기 및 상태 확인
      * - 모임이 확정이 안된 상태이여야 함
+     * - 개설자 정보와 같이 JOIN FETCH
      */
     private MeetingEntity validateAndGetMeeting(Long meetingId) {
-        MeetingEntity meetingEntity = meetingRepository.findById(meetingId)
+        MeetingEntity meetingEntity = meetingRepository.findWithCreatorById(meetingId)
                 .orElseThrow(() -> new MeetingNotFoundException(ErrorCode.MEETING_NOT_FOUND));
 
         if (meetingEntity.getIsConfirmed()) {

--- a/src/main/java/com/example/starhub/service/ApplicationService.java
+++ b/src/main/java/com/example/starhub/service/ApplicationService.java
@@ -28,6 +28,7 @@ public class ApplicationService {
 
     /**
      * 공통 검증 로직: 게시글 가져오기 및 상태 확인
+     * - 모임이 확정이 안된 상태이여야 함
      */
     private MeetingEntity validateAndGetMeeting(Long meetingId) {
         MeetingEntity meetingEntity = meetingRepository.findById(meetingId)

--- a/src/main/java/com/example/starhub/service/ApplicationService.java
+++ b/src/main/java/com/example/starhub/service/ApplicationService.java
@@ -159,19 +159,19 @@ public class ApplicationService {
      *
      * @param username JWT를 통해 인증된 사용자명
      * @param meetingId 모임 아이디
-     * @param applicationId 지원서 아이디
      * @param applicationRequestDto 수정할 지원서 내용
      * @return 수정된 지원서에 대한 DTO
      */
-    public ApplicationResponseDto updateApplication(String username, Long meetingId, Long applicationId, ApplicationRequestDto applicationRequestDto) {
+    public ApplicationResponseDto updateApplication(String username, Long meetingId, ApplicationRequestDto applicationRequestDto) {
 
-        validateAndGetMeeting(meetingId);
+        UserEntity userEntity = validateAndGetUser(username);
+        MeetingEntity meetingEntity = validateAndGetMeeting(meetingId);
 
-        ApplicationEntity applicationEntity = applicationRepository.findById(applicationId)
+        // 개설자가 아님을 확인해야 함
+        validateMeetingApplicant(meetingEntity, username);
+
+        ApplicationEntity applicationEntity = applicationRepository.findByApplicantAndMeeting(userEntity, meetingEntity)
                 .orElseThrow(() -> new ApplicationNotFoundException(ErrorCode.APPLICATION_NOT_FOUND));
-
-        // 지원자인지 확인
-        validateApplicant(applicationEntity, username);
 
         applicationEntity.updateContent(applicationRequestDto.getContent());
 


### PR DESCRIPTION
## 개요
1. 지원서 관련 API 수정 
- 지원서 아이디 -> 경로 변수에서 제거
2. 쿼리 최적화 
- 목록 불러오기에서 지원자 정보는 JOIN FETCH으로 정보 한 꺼번에 불러오기 (n + 1 문제 방지)
- 개설자인지 지원자인지 검증을 위해 모임의 개설자 정보를 매번 불러오고 있음 
  -> 모임을 불러올 때 개설자 정보도 같이 JOIN FETCH 

### 이슈 넘버
#30 

## PR 유형
어떤 변경 사항이 있나요?

- [X]  새로운 기능 추가
- [X]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [ ]  코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ]  코드 리팩토링
- [ ]  주석 추가 및 수정
- [ ]  문서 수정
- [ ]  테스트 추가, 테스트 리팩토링
- [ ]  빌드 부분 혹은 패키지 매니저 수정
- [ ]  파일 혹은 폴더명 수정
- [ ]  파일 혹은 폴더 삭제

## 의논할 부분

## 주의 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **기능 변경**
	- 애플리케이션 관리 엔드포인트가 현재 인증된 사용자 중심으로 변경됨
	- 애플리케이션 상세 조회, 수정, 삭제 시 특정 애플리케이션 ID 대신 현재 사용자의 애플리케이션 처리
	- 미팅 및 애플리케이션 관련 내부 로직 최적화
	- 새로운 미팅 및 애플리케이션 조회 메서드 추가

- **개선 사항**
	- 애플리케이션 관리 프로세스의 사용자 경험 간소화
	- 보안 및 접근 제어 메커니즘 강화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->