### PR TITLE
[PR] 🐛 Fix: 모임 엔티티 및 응답 타입 수정

### DIFF
--- a/src/main/java/com/example/starhub/dto/request/CreateMeetingRequestDto.java
+++ b/src/main/java/com/example/starhub/dto/request/CreateMeetingRequestDto.java
@@ -32,12 +32,12 @@ public class CreateMeetingRequestDto {
     @NotNull(message = "위도 값을 입력해주세요.")
     @DecimalMin(value = "-90.0", inclusive = true, message = "위도는 -90에서 90 사이여야 합니다.")
     @DecimalMax(value = "90.0", inclusive = true, message = "위도는 -90에서 90 사이여야 합니다.")
-    private BigDecimal latitude;
+    private Double latitude;
 
     @NotNull(message = "경도 값을 입력해주세요.")
     @DecimalMin(value = "-180.0", inclusive = true, message = "경도는 -180에서 180 사이여야 합니다.")
     @DecimalMax(value = "180.0", inclusive = true, message = "경도는 -180에서 180 사이여야 합니다.")
-    private BigDecimal longitude;
+    private Double longitude;
 
     @NotBlank(message = "제목을 입력해주세요.")
     @Size(max = 100, message = "제목은 100자 이내로 작성해야 합니다.")

--- a/src/main/java/com/example/starhub/dto/request/MeetingUpdateRequestDto.java
+++ b/src/main/java/com/example/starhub/dto/request/MeetingUpdateRequestDto.java
@@ -16,8 +16,8 @@ public class MeetingUpdateRequestDto {
     private Duration duration;
     private LocalDate endDate;
     private String location;
-    private BigDecimal latitude;
-    private BigDecimal longitude;
+    private Double latitude;
+    private Double longitude;
     private String title;
     private String description;
     private String goal;

--- a/src/main/java/com/example/starhub/dto/response/MeetingResponseDto.java
+++ b/src/main/java/com/example/starhub/dto/response/MeetingResponseDto.java
@@ -21,8 +21,8 @@ public class MeetingResponseDto {
     private Duration duration;
     private LocalDate endDate;
     private String location;
-    private BigDecimal latitude;
-    private BigDecimal longitude;
+    private Double latitude;
+    private Double longitude;
     private String title;
     private String description;
     private String goal;

--- a/src/main/java/com/example/starhub/dto/response/MeetingSummaryResponseDto.java
+++ b/src/main/java/com/example/starhub/dto/response/MeetingSummaryResponseDto.java
@@ -22,8 +22,8 @@ public class MeetingSummaryResponseDto {
     private LocalDate endDate;
     private List<String> techStacks;  // 기술 스택 목록
     private String location;
-    private BigDecimal latitude;
-    private BigDecimal longitude;
+    private Double latitude;
+    private Double longitude;
     private LikeDto likeDto; // 좋아요 관련 정보
 
     /**

--- a/src/main/java/com/example/starhub/entity/MeetingEntity.java
+++ b/src/main/java/com/example/starhub/entity/MeetingEntity.java
@@ -41,9 +41,11 @@ public class MeetingEntity {
     @Column(length = 100)
     private String location;  // 진행 장소
 
-    private BigDecimal latitude;  // 위도
+    @Column(precision = 15, scale = 13) // 최대 정수부 2자리 + 소수부 13자리
+    private Double latitude;  // 위도
 
-    private BigDecimal longitude;  // 경도
+    @Column(precision = 16, scale = 13) // 최대 정수부 3자리 + 소수부 13자리
+    private Double longitude;  // 경도
 
     @Column(length = 100)
     private String title;  // 스터디 제목


### PR DESCRIPTION
<!---- 제목 emoji commitTag: name -->
<!---- [PR] ✨ Feat: login -->

## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요.  -->
- 위도와 경도의 경우, 명확한 구분을 위해 소수점 13자리까지 저장되어야함
  - 기존 BigDecimal의 경우, 소수점 두자리만 표시됨
  - 이에 주변 장소들이 모두 하나의 장소로 표시되는 오류가 발생
- 15~17자리까지 정확도가 표시되는 `Double`로 타입 변경
- 엔티티 변경에 따른 응답 타입도 수정 

### 이슈 넘버

## PR 유형
어떤 변경 사항이 있나요?

- [ ]  새로운 기능 추가
- [x]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [ ]  코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ]  코드 리팩토링
- [ ]  주석 추가 및 수정
- [ ]  문서 수정
- [ ]  테스트 추가, 테스트 리팩토링
- [ ]  빌드 부분 혹은 패키지 매니저 수정
- [ ]  파일 혹은 폴더명 수정
- [ ]  파일 혹은 폴더 삭제

## 의논할 부분

## 주의 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **변경 사항**
	- 위도(latitude)와 경도(longitude) 데이터 타입을 `BigDecimal`에서 `Double`로 변경
	- 데이터베이스 저장 시 위도와 경도의 정밀도 조정
	- 모임 관련 데이터 전송 및 응답 객체의 좌표 표현 방식 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->